### PR TITLE
sort low-stock items to top of inventory lists

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -33,11 +33,19 @@ export default function DashboardPage() {
     const categories = useMemo(() => ["All", ...Array.from(new Set(items.map((i) => i.category)))], [items]);
 
     const filteredItems = useMemo(() => {
-        return items.filter((item) => {
-            const matchesSearch = item.name.toLowerCase().includes(search.toLowerCase());
-            const matchesCategory = category === "All" || item.category === category;
-            return matchesSearch && matchesCategory;
-        });
+        return items
+            .filter((item) => {
+                const matchesSearch = item.name.toLowerCase().includes(search.toLowerCase());
+                const matchesCategory = category === "All" || item.category === category;
+                return matchesSearch && matchesCategory;
+            })
+            .sort((a, b) => {
+                const aLow = a.quantity < a.low_stock_threshold;
+                const bLow = b.quantity < b.low_stock_threshold;
+                if (aLow && !bLow) return -1;
+                if (!aLow && bLow) return 1;
+                return a.name.localeCompare(b.name);
+            });
     }, [items, search, category]);
 
     const handleAdjustClick = (item: InventoryItem, type: "+" | "-") => {

--- a/src/components/admin/InventoryView.tsx
+++ b/src/components/admin/InventoryView.tsx
@@ -56,6 +56,14 @@ export function InventoryView() {
     });
     const router = useRouter();
 
+    const sortedItems = [...items].sort((a, b) => {
+        const aLow = a.quantity < a.low_stock_threshold;
+        const bLow = b.quantity < b.low_stock_threshold;
+        if (aLow && !bLow) return -1;
+        if (!aLow && bLow) return 1;
+        return a.name.localeCompare(b.name);
+    });
+
     const handleSave = async () => {
         if (isSubmitting) return;
         setIsSubmitting(true);
@@ -157,7 +165,7 @@ export function InventoryView() {
                                 </TableCell>
                             </TableRow>
                         ) : (
-                            items.map((item) => (
+                            sortedItems.map((item) => (
                                 <TableRow key={item.id} className="border-white/5 hover:bg-white/5 transition-colors group">
                                     <TableCell className="font-medium">{item.name}</TableCell>
                                     <TableCell>


### PR DESCRIPTION
Low-stock items now float to the top in both the user dashboard grid and the admin inventory table. Once restocked above threshold, they return to their normal alphabetical position automatically.