### PR TITLE
fix: prevent dialogs from closing on Android WebView interactions

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -297,7 +297,7 @@ export default function DashboardPage() {
 
             {/* Adjust stock popup */}
             <Dialog open={!!selectedItem} onOpenChange={() => setSelectedItem(null)}>
-                <DialogContent className="glass-dark border-white/10 rounded-[2xl] sm:max-w-md">
+                <DialogContent className="glass-dark border-white/10 rounded-[2xl] sm:max-w-md" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader className="space-y-4">
                         <DialogTitle className="text-2xl font-bold flex items-center gap-3">
                             <div className={`p-2 rounded-xl ${adjustmentType === '+' ? 'bg-primary/20 text-primary' : 'bg-destructive/20 text-destructive'}`}>

--- a/src/components/admin/AppSettings.tsx
+++ b/src/components/admin/AppSettings.tsx
@@ -220,7 +220,7 @@ export function AppSettingsView() {
 
             {/* Reset Confirmation Dialog */}
             <Dialog open={showResetConfirm} onOpenChange={setShowResetConfirm}>
-                <DialogContent className="glass-dark border-white/10 rounded-[2rem]">
+                <DialogContent className="glass-dark border-white/10 rounded-[2rem]" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader>
                         <DialogTitle className="text-destructive flex items-center gap-2">
                             <AlertTriangle className="w-6 h-6" />

--- a/src/components/admin/InventoryView.tsx
+++ b/src/components/admin/InventoryView.tsx
@@ -439,7 +439,7 @@ export function InventoryView() {
                 setIsAddOpen(open);
                 if (!open) setEditingItem(null);
             }}>
-                <DialogContent className="glass-dark border-white/10 rounded-3xl sm:max-w-lg">
+                <DialogContent className="glass-dark border-white/10 rounded-3xl sm:max-w-lg" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader>
                         <DialogTitle className="text-2xl font-bold">{editingItem ? "Edit Item" : "Add New Item"}</DialogTitle>
                         <DialogDescription>
@@ -515,7 +515,7 @@ export function InventoryView() {
             <Dialog open={!!itemToDelete} onOpenChange={(open) => {
                 if (!open) setItemToDelete(null);
             }}>
-                <DialogContent className="glass-dark border-white/10 rounded-4xl sm:max-w-md">
+                <DialogContent className="glass-dark border-white/10 rounded-4xl sm:max-w-md" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader className="space-y-4">
                         <DialogTitle className="text-2xl font-bold flex items-center gap-3">
                             <div className="p-2 rounded-xl bg-destructive/20 text-destructive">
@@ -550,7 +550,7 @@ export function InventoryView() {
             </Dialog>
             {/* Category Manager Dialog */}
             <Dialog open={isCategoryManagerOpen} onOpenChange={setIsCategoryManagerOpen}>
-                <DialogContent className="glass-dark border-white/10 rounded-3xl sm:max-w-md">
+                <DialogContent className="glass-dark border-white/10 rounded-3xl sm:max-w-md" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader>
                         <DialogTitle className="text-2xl font-bold">Manage Categories</DialogTitle>
                         <DialogDescription>

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -173,7 +173,7 @@ export function UserManagement() {
                 setIsAddOpen(open);
                 if (!open) setEditingUser(null);
             }}>
-                <DialogContent className="glass-dark border-white/10 rounded-3xl sm:max-w-md">
+                <DialogContent className="glass-dark border-white/10 rounded-3xl sm:max-w-md" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader>
                         <DialogTitle className="text-2xl font-bold">{editingUser ? "Edit User" : "Add New User"}</DialogTitle>
                         <DialogDescription>
@@ -230,7 +230,7 @@ export function UserManagement() {
 
             {/* Delete Confirmation */}
             <Dialog open={!!userToDelete} onOpenChange={(open) => !open && setUserToDelete(null)}>
-                <DialogContent className="glass-dark border-white/10 rounded-[2rem] sm:max-w-md">
+                <DialogContent className="glass-dark border-white/10 rounded-[2rem] sm:max-w-md" onInteractOutside={(e) => e.preventDefault()}>
                     <DialogHeader className="space-y-4">
                         <DialogTitle className="text-2xl font-bold flex items-center gap-3">
                             <div className="p-2 rounded-xl bg-destructive/20 text-destructive">


### PR DESCRIPTION
Add onInteractOutside={(e) => e.preventDefault()} to all DialogContent instances. On Android/Capacitor WebView, the soft keyboard opening fires pointer events that Radix UI Dialog interprets as outside clicks, causing dialogs to dismiss mid-form. The Select portal also triggers this, making category/role dropdowns non-functional.

Affected dialogs: add-item, delete-item, category manager (InventoryView), add-user, delete-user (UserManagement), adjust-stock (dashboard), db-reset confirmation (AppSettings).